### PR TITLE
 Reconfigured properties file and added Custom config file

### DIFF
--- a/gamesgalore/src/main/java/com/revature/gamesgalore/CustomConfig.java
+++ b/gamesgalore/src/main/java/com/revature/gamesgalore/CustomConfig.java
@@ -1,0 +1,24 @@
+package com.revature.gamesgalore;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class CustomConfig {
+
+	@Bean
+	@Primary
+	public DataSource dataSource() {
+	    return DataSourceBuilder
+	        .create()
+	        .username(System.getenv("GG_USERNAME"))
+	        .password(System.getenv("GG_PASS"))
+	        .url(System.getenv("GG_URL"))
+	        .driverClassName(System.getenv("GG_DRIVER"))
+	        .build();
+	}
+}

--- a/gamesgalore/src/main/resources/application.properties
+++ b/gamesgalore/src/main/resources/application.properties
@@ -1,8 +1,4 @@
 server.port=8081
-spring.datasource.url=${GG_URL}
-spring.datasource.username=${GG_USERNAME}
-spring.datasource.password=${GG_PASS}
-spring.datasource.driver-class-name = ${GG_DRIVER}
 spring.datasource.initialization-mode=never
 spring.jmx.enabled=false
 spring.jpa.show-sql=true


### PR DESCRIPTION
Per issue #9, the application was not able to read the systems environment variables. Therefore the EC2 could not set up a connection when running the application. I added a custom configuration class which reads the environment variables and removed the lines that attempted to do so from the application.properties file. The solution was tested and working on my windows environment. However it still needs to be tested on the EC2.